### PR TITLE
trim string when checking if there's another shortcode in the content

### DIFF
--- a/class-shortcode-tree.php
+++ b/class-shortcode-tree.php
@@ -132,7 +132,7 @@ class Shortcode {
 					// Siblings
 					$siblings = array ();
 					if (strlen ( $matches [5] [$node_index] )) {
-						if(0 === strpos( $matches [5] [$node_index], '[' ))
+						if(0 === strpos( trim( $matches [5] [$node_index] ), '[' ))
 							$siblings = Shortcode::fromString ( $matches [5] [$node_index] );
 						else
 							$node->setContent($matches [5] [$node_index]);


### PR DESCRIPTION
Hey there,

great little class you got there, I'm really astonished it hasn't gained more traction in 5 years...
Anyway, I fixed a small bug when checking if the content of a parsed shortcode contains another shortcode. If it had some whitespace before the opening square bracket, the content was added as string content instead of parsed sub-nodes.