### PR TITLE
fix: constructor argument $shortcodes was never used

### DIFF
--- a/class-shortcode-tree.php
+++ b/class-shortcode-tree.php
@@ -13,7 +13,7 @@ class Shortcode {
 		$this->name = $name;
 		$this->atts = $atts;
 		$this->content = $content;
-		$this->shortcodes = array ();
+		$this->shortcodes = $shortcodes;
 		
 		$this->parent = $parent;
 	}


### PR DESCRIPTION
The constructor argument of the `Shortcode` class was never used and instead overridden with an empty array:
```php
public function __construct($name = '', $atts = array(), $content = '', $shortcodes = array(), $parent = null) {
	$this->name = $name;
	$this->atts = $atts;
	$this->content = $content;
	$this->shortcodes = array (); // <===
...
```
I encountered this while writing a test case for when #3 is merged.