### PR TITLE
fix findNthOccurrence failing with "Undefined offset: 0"

### DIFF
--- a/class-shortcode-tree.php
+++ b/class-shortcode-tree.php
@@ -96,7 +96,7 @@ class Shortcode {
 			return ! is_null ( $o );
 		} );
 		
-		return reset( $occurrences[0] );
+		return reset( $occurrences );
 	}
 	
 	public function findAll ($shortcode_name) {

--- a/class-shortcode-tree.php
+++ b/class-shortcode-tree.php
@@ -96,7 +96,7 @@ class Shortcode {
 			return ! is_null ( $o );
 		} );
 		
-		return reset( $occurrences );
+		return reset( $occurrences ) ?: null;
 	}
 	
 	public function findAll ($shortcode_name) {

--- a/class-shortcode-tree.php
+++ b/class-shortcode-tree.php
@@ -96,7 +96,7 @@ class Shortcode {
 			return ! is_null ( $o );
 		} );
 		
-		return $occurrences[0];
+		return reset( $occurrences[0] );
 	}
 	
 	public function findAll ($shortcode_name) {


### PR DESCRIPTION
`findNthOccurrence()` would sometimes fail with the error `Undefined offset: 0`, when the first element was `null` before `array_filter()` was applied, effectively removing the first element without resetting the indices and therefore not having an index `0`.